### PR TITLE
#27 refactor jpa repository (edited commit message)

### DIFF
--- a/src/main/java/com/healthshop/healthshop/repository/OrderRepository.java
+++ b/src/main/java/com/healthshop/healthshop/repository/OrderRepository.java
@@ -1,12 +1,8 @@
 package com.healthshop.healthshop.repository;
 
 import com.healthshop.healthshop.domain.order.Order;
-import jakarta.persistence.EntityManager;
-import lombok.RequiredArgsConstructor;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface OrderRepository extends JpaRepository<Order, Long> {

--- a/src/main/java/com/healthshop/healthshop/service/MemberService.java
+++ b/src/main/java/com/healthshop/healthshop/service/MemberService.java
@@ -3,7 +3,6 @@ package com.healthshop.healthshop.service;
 import com.healthshop.healthshop.domain.member.Member;
 import com.healthshop.healthshop.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/healthshop/healthshop/service/OrderService.java
+++ b/src/main/java/com/healthshop/healthshop/service/OrderService.java
@@ -35,7 +35,9 @@ public class OrderService {
     public Long order(Long memberId, List<ItemQuantity> itemQuantities, PaymentMethod payment) {
 
         // 엔티티 조회
-        Member member = memberRepository.findById(memberId).orElse(null);
+        Member member = memberRepository.findById(memberId).orElseThrow(() ->
+                new IllegalArgumentException("Invalid member ID: " + memberId));
+
 
         // 배송정보 생성
         DeliveryAddress deliveryAddress;
@@ -75,7 +77,8 @@ public class OrderService {
     @Transactional
     public void cancelOrder(Long orderId) {
         // 주문 엔티티 조회
-        Order order = orderRepository.findById(orderId).orElse(null);
+        Order order = orderRepository.findById(orderId).orElseThrow(() ->
+                new IllegalArgumentException("Invalid order ID: " + orderId));
         // 주문 취소
         order.cancel();
     }

--- a/src/test/java/com/healthshop/healthshop/service/MemberServiceTest.java
+++ b/src/test/java/com/healthshop/healthshop/service/MemberServiceTest.java
@@ -8,8 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest

--- a/src/test/java/com/healthshop/healthshop/service/OrderServiceTest.java
+++ b/src/test/java/com/healthshop/healthshop/service/OrderServiceTest.java
@@ -49,7 +49,8 @@ class OrderServiceTest {
         Long orderId = orderService.order(member.getId(), itemQuantities, payment);
 
         //then
-        Order getOrder = orderRepository.findById(orderId).orElse(null);
+        Order getOrder = orderRepository.findById(orderId).orElseThrow(() ->
+                new IllegalArgumentException("Invalid order ID: " + orderId));;
 
         // 1. 상품 주문 시 상태는 COMPLETE
         assertEquals(OrderStatus.COMPLETE, getOrder.getStatus());
@@ -81,7 +82,8 @@ class OrderServiceTest {
         Long orderId = orderService.order(member.getId(), itemQuantities, payment);
 
         //then
-        Order getOrder = orderRepository.findById(orderId).orElse(null);
+        Order getOrder = orderRepository.findById(orderId).orElseThrow(() ->
+                new IllegalArgumentException("Invalid order ID: " + orderId));
 
         // 1. 상품 주문 시 상태는 COMPLETE
         assertEquals(OrderStatus.COMPLETE, getOrder.getStatus());
@@ -149,7 +151,7 @@ class OrderServiceTest {
         orderService.cancelOrder(orderId);
 
         //then
-        Order getOrder = orderRepository.findById(orderId).orElse(null);
+        Order getOrder = orderRepository.findById(orderId).orElseThrow(() -> new IllegalArgumentException("Invalid order ID: " + orderId));
 
         // 1. 주문 취소 시 상태는 CANCEL
         assertEquals(OrderStatus.CANCEL, getOrder.getStatus());


### PR DESCRIPTION
- 기존 Repository 클래스를 모두 JpaRepository를 확장하는 인터페이스 형식으로 리팩토링했다.
- 서비스 계층 및 컨트롤러 계층에서 그대로 기능이 동작하도록 했다.

(이 PR은 기존 PR에서 커밋 메시지를 잘못 입력하여 수정 후 다시 적용하는 PR이다.)