### PR TITLE
#28 item search

### DIFF
--- a/src/main/java/com/healthshop/healthshop/controller/ItemController.java
+++ b/src/main/java/com/healthshop/healthshop/controller/ItemController.java
@@ -21,20 +21,13 @@ public class ItemController {
 
     private final ItemService itemService;
 
-//    @GetMapping("/shop")
-//    public String shop(Model model) {
-//        List<Item> items = itemService.findItems();
-//        List<ItemDto> itemDtos = items.stream()
-//                .map(ItemConverter::toDto)
-//                .toList();
-//        model.addAttribute("items", itemDtos);
-//        return "shop";
-//    }
-
     @GetMapping("/shop")
-    public String shop(@RequestParam(defaultValue = "0") int page, Model model) {
+    public String shop(@RequestParam(defaultValue = "0") int page,
+                       @RequestParam(defaultValue = "") String keyword,
+                       @RequestParam(defaultValue = "idDesc") String sort,
+                       Model model) {
         PageRequest pageRequest = PageRequest.of(page, 12);
-        Page<Item> itemsPage = itemService.findItems(pageRequest);
+        Page<Item> itemsPage = itemService.findItems(keyword, sort, pageRequest);
         List<ItemDto> itemDtos = itemsPage.getContent().stream()
                 .map(ItemConverter::toDto)
                 .toList();
@@ -42,6 +35,8 @@ public class ItemController {
         model.addAttribute("items", itemDtos);
         model.addAttribute("currentPage", page);
         model.addAttribute("totalPages", itemsPage.getTotalPages());
+        model.addAttribute("keyword", keyword);
+        model.addAttribute("sort", sort);
         return "shop";
     }
 

--- a/src/main/java/com/healthshop/healthshop/repository/ItemRepository.java
+++ b/src/main/java/com/healthshop/healthshop/repository/ItemRepository.java
@@ -2,8 +2,9 @@ package com.healthshop.healthshop.repository;
 
 import com.healthshop.healthshop.domain.item.Item;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ItemRepository extends JpaRepository<Item, Long> {
+public interface ItemRepository extends JpaRepository<Item, Long>, JpaSpecificationExecutor<Item> {
 }

--- a/src/main/java/com/healthshop/healthshop/repository/ItemSpecifications.java
+++ b/src/main/java/com/healthshop/healthshop/repository/ItemSpecifications.java
@@ -10,7 +10,7 @@ public class ItemSpecifications {
                 criteriaBuilder.like(root.get("name"), "%" + keyword + "%");
     }
 
-    // 낮은 가격순
+    // 낮은 가격순 (할인율 반영)
     public static Specification<Item> sortByPriceDesc() {
         return (root, query, criteriaBuilder) -> {
             query.orderBy(criteriaBuilder.desc(
@@ -54,7 +54,7 @@ public class ItemSpecifications {
         };
     }
 
-    // 추가순 (id 높은순)
+    // 신상품순 (id 높은 순)
     public static Specification<Item> sortByIdDesc() {
         return (root, query, criteriaBuilder) -> {
             query.orderBy(criteriaBuilder.desc(root.get("id")));

--- a/src/main/java/com/healthshop/healthshop/repository/ItemSpecifications.java
+++ b/src/main/java/com/healthshop/healthshop/repository/ItemSpecifications.java
@@ -13,15 +13,35 @@ public class ItemSpecifications {
     // 낮은 가격순
     public static Specification<Item> sortByPriceDesc() {
         return (root, query, criteriaBuilder) -> {
-            query.orderBy(criteriaBuilder.desc(root.get("price")));
+            query.orderBy(criteriaBuilder.desc(
+                criteriaBuilder.diff(  // -
+                    root.get("price"),
+                    criteriaBuilder.prod(  // *
+                        root.get("discountRate"),
+                        criteriaBuilder.quot(  // /
+                            root.get("price"), 100
+                        )
+                    )
+                )
+            ));
             return null;
         };
     }
 
-    // 높은 가격순
+    // 높은 가격순 (할인율 반영)
     public static Specification<Item> sortByPriceAsc() {
         return (root, query, criteriaBuilder) -> {
-            query.orderBy(criteriaBuilder.asc(root.get("price")));
+            query.orderBy(criteriaBuilder.asc(
+                criteriaBuilder.diff(  // -
+                    root.get("price"),
+                    criteriaBuilder.prod(  // *
+                        root.get("discountRate"),
+                        criteriaBuilder.quot(  // /
+                            root.get("price"), 100
+                        )
+                    )
+                )
+            ));
             return null;
         };
     }

--- a/src/main/java/com/healthshop/healthshop/service/ItemService.java
+++ b/src/main/java/com/healthshop/healthshop/service/ItemService.java
@@ -2,9 +2,11 @@ package com.healthshop.healthshop.service;
 
 import com.healthshop.healthshop.domain.item.Item;
 import com.healthshop.healthshop.repository.ItemRepository;
+import com.healthshop.healthshop.repository.ItemSpecifications;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,11 +30,21 @@ public class ItemService {
     }
 
     public Item findOne(Long id) {
-        Optional<Item> optionalItem = itemRepository.findById(id);
-        return optionalItem.orElse(null);
+        return itemRepository.findById(id).orElse(null);
     }
 
-    public Page<Item> findItems(PageRequest pageRequest) {
-        return itemRepository.findAll(pageRequest);
+    public Page<Item> findItems(String keyword, String sort, PageRequest pageRequest) {
+        // 주어진 키워드로 Item의 name 필드 검색하는 조건 생성
+        Specification<Item> spec = Specification.where(ItemSpecifications.hasKeyword(keyword));
+
+        spec = switch (sort) {
+            case "priceDesc" -> spec.and(ItemSpecifications.sortByPriceDesc());
+            case "priceAsc" -> spec.and(ItemSpecifications.sortByPriceAsc());
+            case "discountRateDesc" -> spec.and(ItemSpecifications.sortByDiscountRateDesc());
+            case "idDesc" -> spec.and(ItemSpecifications.sortByIdDesc());
+            default -> spec;
+        };
+
+        return itemRepository.findAll(spec, pageRequest);
     }
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -814,3 +814,38 @@ textarea {
   vertical-align: middle; /* 버튼을 텍스트 중앙에 맞춤 */
   text-align: center;
 }
+
+/* Dropdown 버튼의 스타일 변경 */
+.dropdown-toggle {
+ background-color: #435C52 !important; /* 배경 색상 */
+ color: white !important; /* 텍스트 색상 */
+ border-radius: 1rem; /* 테두리 둥글기 */
+ padding: 12px 30px; /* 내부 여백 */
+}
+
+.dropdown-toggle:hover {
+  background-color: #646464; /* 호버 시 배경 색상 */
+  color: white; /* 호버 시 텍스트 색상 */
+}
+
+/* Dropdown 메뉴의 스타일 변경 */
+.dropdown-menu {
+  background-color: #f8f9fa; /* 메뉴 배경 색상 */
+  border: 1px solid #ced4da; /* 테두리 색상 */
+  border-radius: 5px; /* 테두리 둥글기 */
+  width: 200px; /* 메뉴 너비 */
+  max-height: 300px; /* 최대 높이 */
+  overflow-y: auto; /* 세로 스크롤 */
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* 그림자 */
+}
+
+/* Dropdown 항목의 스타일 변경 */
+.dropdown-item {
+  color: #343a40; /* 항목 텍스트 색상 */
+  padding: 10px 20px; /* 내부 여백 */
+}
+
+.dropdown-item:hover {
+  background-color: #e9ecef; /* 호버 시 배경 색상 */
+  color: #212529; /* 호버 시 텍스트 색상 */
+}

--- a/src/main/resources/templates/shop.html
+++ b/src/main/resources/templates/shop.html
@@ -28,6 +28,37 @@
 <!-- Start Product Section -->
 <div class="untree_co-section product-section before-footer-section">
   <div class="container">
+    <!-- 상품 정렬 및 검색 -->
+    <div class="row mb-5 justify-content-center">
+      <div class="col-md-9">
+        <div class="row">
+          <div class="col-md-2 d-flex align-items-center">
+            <div class="dropdown w-100">
+              <button class="btn btn-secondary dropdown-toggle w-100" type="button" id="sortDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+                <span id="sortDropdownText">정렬</span>
+              </button>
+              <ul class="dropdown-menu" aria-labelledby="sortDropdown">
+                <li><a class="dropdown-item" href="#" onclick="setSort('idDesc', '신상품순')">신상품순</a></li>
+                <li><a class="dropdown-item" href="#" onclick="setSort('priceDesc', '높은 가격순')">높은 가격순</a></li>
+                <li><a class="dropdown-item" href="#" onclick="setSort('priceAsc', '낮은 가격순')">낮은 가격순</a></li>
+                <li><a class="dropdown-item" href="#" onclick="setSort('discountRateDesc', '할인율순')">할인율순</a></li>
+              </ul>
+              <form id="sortForm" th:action="@{/shop}" method="get" style="display:none;">
+                <input type="hidden" name="sort" id="sortInput" th:value="${sort}">
+              </form>
+            </div>
+          </div>
+          <div class="col-md-10">
+            <form th:action="@{/shop}" method="get" class="d-flex">
+              <input type="text" name="keyword" class="form-control me-4" placeholder="Search products..." th:value="${keyword}">
+              <button type="submit" class="btn btn-primary">Search</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 상품 목록 -->
     <div class="row">
 
       <div th:each="item : ${items}" class="col-12 col-md-4 col-lg-3 mb-5">
@@ -90,6 +121,26 @@
 <script src="/js/bootstrap.bundle.min.js"></script>
 <script src="/js/tiny-slider.js"></script>
 <script src="/js/custom.js"></script>
+<script>
+  function setSort(value, text) {
+    document.getElementById('sortInput').value = value;
+    document.getElementById('sortDropdownText').innerText = text;
+    document.getElementById('sortForm').submit();
+  }
+
+  // 페이지 로드할 때마다 드롭다운 텍스트 초기화
+  document.addEventListener('DOMContentLoaded', function() {
+    const sortValue = document.getElementById('sortInput').value;
+    let sortText = '정렬';
+    if (sortValue === 'idDesc') sortText = '신상품순';
+    else if (sortValue === 'priceDesc') sortText = '높은 가격순';
+    else if (sortValue === 'priceAsc') sortText = '낮은 가격순';
+    else if (sortValue === 'discountRateDesc') sortText = '할인율순';
+
+    document.getElementById('sortDropdownText').innerText = sortText;
+  });
+</script>
+
 </body>
 
 </html>

--- a/src/test/java/com/healthshop/healthshop/repository/ItemSpecificationsTest.java
+++ b/src/test/java/com/healthshop/healthshop/repository/ItemSpecificationsTest.java
@@ -1,0 +1,35 @@
+package com.healthshop.healthshop.repository;
+
+import com.healthshop.healthshop.domain.item.Item;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@SpringBootTest
+@Transactional
+class ItemSpecificationsTest {
+
+    // data.sql 가져온 상태에서 테스트 실행할 것! (application.yml 수정 필요)
+
+    @Autowired
+    ItemRepository itemRepository;
+
+    @Test
+    void sortByPriceDesc() {
+        Specification<Item> spec = ItemSpecifications.sortByPriceDesc();
+        Page<Item> items = itemRepository.findAll(spec, PageRequest.of(0, 10));
+        items.forEach(item -> System.out.println(item.getName() + ": " + (item.getPrice() - (item.getPrice() * item.getDiscountRate() / 100.0))));
+    }
+
+    @Test
+    void sortByPriceAsc() {
+        Specification<Item> spec = ItemSpecifications.sortByPriceAsc();
+        Page<Item> items = itemRepository.findAll(spec, PageRequest.of(0, 10));
+        items.forEach(item -> System.out.println(item.getName() + ": " + (item.getPrice() - (item.getPrice() * item.getDiscountRate() / 100.0))));
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,18 +1,5 @@
 spring:
-#  datasource:
-#    url: jdbc:h2:tcp://localhost/~/health-shop
-#    username: sa
-#    password:
-#    driver-class-name: org.h2.Driver
-#
-#  jpa:
-#    hibernate:
-#      ddl-auto: create
-#    properties:
-#      hibernate:
-#        show_sql: true
-#        format_sql: true
-
+  #--- data.sql 필요한 경우 주석 처리 ---#
   sql:
     init:
       data-locations:
@@ -22,6 +9,7 @@ spring:
     driver-class-name: org.h2.Driver
     username: sa
     password: password
+  #--------------------------------------#
   jpa:
     defer-datasource-initialization: true  # hibernate 초기화 이후 data.sql이 실행되도록 변경
 


### PR DESCRIPTION
shop 페이지에서 상품 정렬 및 검색 가능하도록 구현했다.
현재 상품 정렬, 검색어를 통한 검색 각각 단독으로는 잘 동작하지만 함께 적용 시 약간의 문제가 있다.

추후 개선해야 할 부분은 아래와 같다.
- 특정 정렬 버튼을 누른 뒤 페이지를 이동하면 ‘신상품순’으로 복구되는 문제
- 특정 정렬 버튼을 누른 뒤 검색어를 입력 후 검색하면 ‘신상품순’인 상태로 복구되어 검색되는 문제