### PR TITLE
#29 improve item search

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -819,7 +819,7 @@ textarea {
 .dropdown-toggle {
  background-color: #435C52 !important; /* 배경 색상 */
  color: white !important; /* 텍스트 색상 */
- border-radius: 1rem; /* 테두리 둥글기 */
+ border-radius: 1.5rem; /* 테두리 둥글기 */
  padding: 12px 30px; /* 내부 여백 */
 }
 

--- a/src/main/resources/templates/shop.html
+++ b/src/main/resources/templates/shop.html
@@ -90,7 +90,7 @@
     <nav aria-label="Page navigation">
       <ul class="pagination justify-content-center">
         <li class="page-item prev-btn" th:classappend="${currentPage == 0} ? 'disabled'">
-          <a class="page-link" th:href="@{/shop(page=${currentPage - 1})}" aria-label="Previous">
+          <a class="page-link" th:href="@{/shop(page=${currentPage - 1}, sort=${sort}, keyword=${keyword})}" aria-label="Previous">
             <span aria-hidden="true">Prev</span>
           </a>
         </li>
@@ -98,11 +98,11 @@
         <li class="page-item" th:each="i : ${#numbers.sequence(0, totalPages - 1)}"
             th:if="${i >= currentPage - 4 and i <= currentPage + 4}"
             th:classappend="${i == currentPage} ? 'active'">
-          <a class="page-link" th:href="@{/shop(page=${i})}" th:text="${i + 1}">1</a>
+          <a class="page-link" th:href="@{/shop(page=${i}, sort=${sort}, keyword=${keyword})}" th:text="${i + 1}">1</a>
         </li>
 
         <li class="page-item next-btn" th:classappend="${currentPage + 1 == totalPages} ? 'disabled'">
-          <a class="page-link" th:href="@{/shop(page=${currentPage + 1})}" aria-label="Next">
+          <a class="page-link" th:href="@{/shop(page=${currentPage + 1}, sort=${sort}, keyword=${keyword})}" aria-label="Next">
             <span aria-hidden="true">Next</span>
           </a>
         </li>

--- a/src/main/resources/templates/shop.html
+++ b/src/main/resources/templates/shop.html
@@ -91,27 +91,29 @@
     </div>
 
     <!-- Start Pagination -->
-    <nav aria-label="Page navigation">
-      <ul class="pagination justify-content-center">
-        <li class="page-item prev-btn" th:classappend="${currentPage == 0} ? 'disabled'">
-          <a class="page-link" th:href="@{/shop(page=${currentPage - 1}, sort=${sort}, keyword=${keyword})}" aria-label="Previous">
-            <span aria-hidden="true">Prev</span>
-          </a>
-        </li>
+    <div th:if="${totalPages > 0}">
+      <nav aria-label="Page navigation">
+        <ul class="pagination justify-content-center">
+          <li class="page-item prev-btn" th:classappend="${currentPage == 0} ? 'disabled'">
+            <a class="page-link" th:href="@{/shop(page=${currentPage - 1}, sort=${sort}, keyword=${keyword})}" aria-label="Previous">
+              <span aria-hidden="true">Prev</span>
+            </a>
+          </li>
 
-        <li class="page-item" th:each="i : ${#numbers.sequence(0, totalPages - 1)}"
-            th:if="${i >= currentPage - 4 and i <= currentPage + 4}"
-            th:classappend="${i == currentPage} ? 'active'">
-          <a class="page-link" th:href="@{/shop(page=${i}, sort=${sort}, keyword=${keyword})}" th:text="${i + 1}">1</a>
-        </li>
+          <li class="page-item" th:each="i : ${#numbers.sequence(0, totalPages - 1)}"
+              th:if="${i >= currentPage - 4 and i <= currentPage + 4}"
+              th:classappend="${i == currentPage} ? 'active'">
+            <a class="page-link" th:href="@{/shop(page=${i}, sort=${sort}, keyword=${keyword})}" th:text="${i + 1}">1</a>
+          </li>
 
-        <li class="page-item next-btn" th:classappend="${currentPage + 1 == totalPages} ? 'disabled'">
-          <a class="page-link" th:href="@{/shop(page=${currentPage + 1}, sort=${sort}, keyword=${keyword})}" aria-label="Next">
-            <span aria-hidden="true">Next</span>
-          </a>
-        </li>
-      </ul>
-    </nav>
+          <li class="page-item next-btn" th:classappend="${currentPage + 1 == totalPages} ? 'disabled'">
+            <a class="page-link" th:href="@{/shop(page=${currentPage + 1}, sort=${sort}, keyword=${keyword})}" aria-label="Next">
+              <span aria-hidden="true">Next</span>
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </div>
     <!-- End Pagination -->
 
   </div>

--- a/src/main/resources/templates/shop.html
+++ b/src/main/resources/templates/shop.html
@@ -51,6 +51,7 @@
           <div class="col-md-10">
             <form th:action="@{/shop}" method="get" class="d-flex">
               <input type="text" name="keyword" class="form-control me-4" placeholder="Search products..." th:value="${keyword}">
+              <input type="hidden" name="sort" th:value="${sort}">
               <button type="submit" class="btn btn-primary">Search</button>
             </form>
           </div>

--- a/src/main/resources/templates/shop.html
+++ b/src/main/resources/templates/shop.html
@@ -61,6 +61,9 @@
 
     <!-- 상품 목록 -->
     <div class="row">
+      <div th:if="${items.isEmpty()}">
+        <p class="text-center mt-4 mb-4">상품 검색 결과가 없습니다.</p>
+      </div>
 
       <div th:each="item : ${items}" class="col-12 col-md-4 col-lg-3 mb-5">
         <a class="product-item" th:href="@{/shop/item/{id}(id=*{item.id})}">
@@ -129,7 +132,7 @@
     document.getElementById('sortForm').submit();
   }
 
-  // 페이지 로드할 때마다 드롭다운 텍스트 초기화
+  // 페이지 로드할 때마다 선택한 정렬값으로 드롭다운 텍스트 초기화
   document.addEventListener('DOMContentLoaded', function() {
     const sortValue = document.getElementById('sortInput').value;
     let sortText = '정렬';


### PR DESCRIPTION
1. 특정 정렬 버튼을 누른 뒤 페이지를 이동하면 ‘추가순’으로 복구되는 문제를 해결했다.
2. 특정 정렬 버튼을 누른 뒤 검색어를 입력 후 검색하면 ‘추가순’인 상태로 복구되어 검색되는 문제를 해결했다.
3. 검색된 상품이 없을 때 메시지를 표시하고, 페이지네이션 컴포넌트는 렌더링하지 않도록 수정했다.