### PR TITLE
[feat] 상품 관리 페이지에서 이미지 업로드 기능 구현

### DIFF
--- a/src/main/java/com/healthshop/healthshop/controller/ItemController.java
+++ b/src/main/java/com/healthshop/healthshop/controller/ItemController.java
@@ -15,7 +15,9 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 @Controller
@@ -64,7 +66,7 @@ public class ItemController {
         itemForm.setPrice(item.getPrice());
         itemForm.setDiscountRate(item.getDiscountRate());
         itemForm.setBrand(item.getBrand());
-        // itemForm.setImgPath(item.getImgPath());
+        itemForm.setImgPath(item.getImgPath());
         itemForm.setDescription(item.getDescription());
         itemForm.setStockQuantity(item.getStockQuantity());  // 직접 입력은 불가, 수량 증가 버튼으로 늘리도록
 
@@ -78,7 +80,8 @@ public class ItemController {
     public String editItemForm(@ModelAttribute("itemForm") @Valid ItemForm form,
                                BindingResult bindingResult,
                                @PathVariable Long itemId,
-                               Model model) {
+                               @RequestParam("imgFile") MultipartFile imgFile,
+                               Model model) throws IOException {
         if (bindingResult.hasErrors()) {
             List<Category> categories = categoryService.findCategories();
 
@@ -94,7 +97,10 @@ public class ItemController {
         item.setPrice(form.getPrice());
         item.setDiscountRate(form.getDiscountRate());
         item.setBrand(form.getBrand());
-        // item.setImgPath(form.getImgPath());
+        if (!imgFile.isEmpty()) {
+            String imgPath = itemService.saveImage(imgFile);
+            item.setImgPath(imgPath);
+        }
         item.setDescription(form.getDescription());
         item.setStockQuantity(item.getStockQuantity());
         itemService.saveItem(item);

--- a/src/main/java/com/healthshop/healthshop/controller/form/ItemForm.java
+++ b/src/main/java/com/healthshop/healthshop/controller/form/ItemForm.java
@@ -3,6 +3,7 @@ package com.healthshop.healthshop.controller.form;
 import jakarta.validation.constraints.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter @Setter
 public class ItemForm {
@@ -25,6 +26,8 @@ public class ItemForm {
     private String brand;
 
     private String imgPath;
+
+    private MultipartFile imgFile;
 
     @NotBlank(message = "상품 설명은 필수 입력값입니다.")
     private String description;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,12 +19,26 @@ spring:
 #        show_sql: true
         format_sql: true
     defer-datasource-initialization: true  # hibernate 초기화 이후 data.sql이 실행되도록 변경
+
   sql:
     init:
       mode: never  # data.sql 스크립트 실행 여부
+
+  devtools:
+    livereload:
+      enabled: true  # 코드 변경 시 브라우저를 자동으로 새로고침
+    restart:
+      enabled: true  # 코드 변경 시 애플리케이션을 자동으로 재시작
+
+  thymeleaf:
+    cache: false  # 템플릿 파일 캐싱 비활성화, 운영 시 활성화로 변경할 것
 
 logging:
   level:
     org:
       hibernate.SQL: debug
 #      springframework.security: debug  # 임시로 추가
+
+image:
+  upload:
+    dir: src/main/resources/static/images/items/  # 추후 수정 필요

--- a/src/main/resources/templates/item/manage.html
+++ b/src/main/resources/templates/item/manage.html
@@ -15,7 +15,7 @@
                     <div class="card" style="border-radius: 15px;">
                         <div class="card-body p-5">
 
-                            <form role="form" th:action="@{/shop/item/manage/{itemId}(itemId=${itemForm.itemId})}" th:object="${itemForm}" method="post" onsubmit="return validateForm()">
+                            <form role="form" th:action="@{/shop/item/manage/{itemId}(itemId=${itemForm.itemId})}" th:object="${itemForm}" method="post" enctype="multipart/form-data" onsubmit="return validateForm()">
                                 <h2 class="text-center bold-text text-black mb-4" th:text="*{name}">Item Name</h2>
                                 <h6 class="text-center text-black mb-5">상품 관리 페이지</h6>
                                 <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
@@ -71,6 +71,20 @@
                                 </div>
 
 <!--                                TODO 3: 사진 입력-->
+<!--                                <div data-mdb-input-init class="form-outline mb-4">-->
+<!--                                    <label class="form-label">상품 이미지</label>-->
+<!--                                    <img th:src="@{${itemForm.imgPath}}" id="currentImage" class="img-fluid" alt="상품 이미지">-->
+<!--                                    <label class="form-label mt-3" for="imageUpload">상품 이미지 변경</label>-->
+<!--                                    <input type="file" id="imageUpload" name="image" class="form-control" accept="image/*" onchange="previewImage(event)">-->
+<!--                                </div>-->
+
+                                <div data-mdb-input-init class="form-outline mb-4">
+                                    <label class="form-label" th:for="imgPath">상품 이미지</label>
+                                    <input type="file" id="imgPath" name="imgFile" class="form-control" accept="image/*" onchange="previewImage(event)"/>
+                                    <div class="mt-3">
+                                        <img id="imgPreview" th:src="@{${itemForm.imgPath}}" class="img-fluid" alt="Image Preview">
+                                    </div>
+                                </div>
 
                                 <div data-mdb-input-init class="form-outline mb-4">
                                     <label class="form-label" th:for="description">상품 설명</label>
@@ -88,7 +102,7 @@
 
                                 <div class="d-flex justify-content-center">
                                     <button type="submit" data-mdb-button-init
-                                            data-mdb-ripple-init class="btn bg-warning btn-block text-body">수정</button>
+                                            data-mdb-ripple-init class="btn bg-warning btn-block text-body">상품 수정</button>
                                 </div>
 
                             </form>
@@ -107,6 +121,20 @@
 <script src="/js/bootstrap.bundle.min.js"></script>
 <script src="/js/validate-form.js"></script>
 <script src="/js/discount-calculator.js"></script>
+<script>
+    function validateForm() {
+        return confirm("정말로 변경사항을 반영하시겠습니까?");
+    }
+
+    function previewImage(event) {
+        const reader = new FileReader();
+        reader.onload = function(){
+            const output = document.getElementById('imgPreview');
+            output.src = reader.result;
+        };
+        reader.readAsDataURL(event.target.files[0]);
+    }
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
상품 관리 페이지에서 상품 이미지 변경 기능(상품 업로드 기능) 구현을 완료했다.

추후 개선해야 할 사항
- 이미지를 업로드한 직후에는 404 오류와 함께 변경된 이미지를 제대로 불러오지 않는 문제가 있다. (이는 Spring Boot가 정적 리소스를 컴파일 타임에 로드하기 때문으로, 런타임에 추가된 파일은 서버를 재시작하지 않는 한 접근할 수 없다.)
- 서버 재시작 방지를 위해 application.yml에 devtools 관련 설정과 thymeleaf 관련 설정을 추가했으나, 여전히 이미지 업로드 이후에 브라우저를 새로고침해줘야 하는 번거로움이 있다.
- 따라서 내부 폴더가 아닌 외부 폴더를 사용하여 저장하는 방식을 검토해보자. (WebMvcConfiguration 등 사용 필요)