### PR TITLE
#45 secure item manage controller

### DIFF
--- a/src/main/java/com/healthshop/healthshop/SecurityConfig.java
+++ b/src/main/java/com/healthshop/healthshop/SecurityConfig.java
@@ -21,7 +21,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((authorize) -> authorize
                         .requestMatchers("/css/**", "/images/**", "/fonts/**", "/js/**", "/scss/**", "/error",
                                 "/", "/login", "/signup", "/signup/success", "/shop").permitAll()
-                        .requestMatchers("/shop/item/manage/**").hasAuthority("ROLE_ADMIN")
+                        .requestMatchers("/manage/**").hasAuthority("ROLE_ADMIN")
                         .anyRequest().authenticated()
                 )
                 .formLogin(formLogin -> formLogin

--- a/src/main/java/com/healthshop/healthshop/controller/item/ItemManagementController.java
+++ b/src/main/java/com/healthshop/healthshop/controller/item/ItemManagementController.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 import java.util.List;
 
 @Controller
-@RequestMapping("/shop/item/manage")
+@RequestMapping("/manage/item")
 @RequiredArgsConstructor
 public class ItemManagementController {
 

--- a/src/main/java/com/healthshop/healthshop/controller/item/ItemManagementController.java
+++ b/src/main/java/com/healthshop/healthshop/controller/item/ItemManagementController.java
@@ -7,6 +7,7 @@ import com.healthshop.healthshop.service.CategoryService;
 import com.healthshop.healthshop.service.ItemService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -19,6 +20,7 @@ import java.util.List;
 @Controller
 @RequestMapping("/manage/item")
 @RequiredArgsConstructor
+@PreAuthorize("hasRole('ROLE_ADMIN')")
 public class ItemManagementController {
 
     public final ItemService itemService;

--- a/src/main/resources/templates/item/create.html
+++ b/src/main/resources/templates/item/create.html
@@ -21,7 +21,7 @@
                 </a>
               </div>
 
-              <form role="form" action="/shop/item/manage/create" th:object="${itemForm}" th:method="post" enctype="multipart/form-data" onsubmit="return validateCreateItemForm()">
+              <form role="form" action="/manage/item/create" th:object="${itemForm}" th:method="post" enctype="multipart/form-data" onsubmit="return validateCreateItemForm()">
 
                 <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" id="csrfToken"/>
 

--- a/src/main/resources/templates/item/item.html
+++ b/src/main/resources/templates/item/item.html
@@ -23,7 +23,7 @@
                 <div style="display: flex; align-items: center;">
                     <h1 th:text="${item.name}" class="display-5 fw-bolder text-black me-2">Shop item</h1>
                     <th:block th:if="${#authorization.expression('hasRole(''ROLE_ADMIN'')')}">
-                        <a class="btn small-button mt-3 bg-danger" type="button" th:href="@{'/shop/item/manage/' + ${item.id}}">상품 관리 페이지</a>
+                        <a class="btn small-button mt-3 bg-danger" type="button" th:href="@{'/manage/item/' + ${item.id}}">상품 관리 페이지</a>
                     </th:block>
                 </div>
                 <!-- 상품 가격 -->

--- a/src/main/resources/templates/item/manage.html
+++ b/src/main/resources/templates/item/manage.html
@@ -20,7 +20,7 @@
                                     &lt; 상품 페이지로 이동
                                 </a>
 
-                                <form th:action="@{/shop/item/manage/{itemId}(itemId = ${itemForm.itemId})}" th:method="delete" onsubmit="return validateDeleteItemForm()">
+                                <form th:action="@{/manage/item/{itemId}(itemId = ${itemForm.itemId})}" th:method="delete" onsubmit="return validateDeleteItemForm()">
                                     <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" id="deleteCsrfToken"/>
                                     <button type="submit" class="btn bg-danger btn-block text-white ms-2">
                                         상품 삭제
@@ -29,7 +29,7 @@
 
                             </div>
 
-                            <form role="form" th:action="@{/shop/item/manage/{itemId}(itemId=${itemForm.itemId})}" th:object="${itemForm}" th:method="put" enctype="multipart/form-data" onsubmit="return validateUpdateItemForm()">
+                            <form role="form" th:action="@{/manage/item/{itemId}(itemId=${itemForm.itemId})}" th:object="${itemForm}" th:method="put" enctype="multipart/form-data" onsubmit="return validateUpdateItemForm()">
 
                                 <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" id="putCsrfToken"/>
 


### PR DESCRIPTION
1. 상품 관리 컨트롤러의 URL 엔드포인트를 다음과 같이 변경했다.
    - 변경 전: `/shop/item/manage/`
    - 변경 후: `/manage/item/`

2. 관리자(admin)만 상품 관리 컨트롤러에 접근할 수 있도록 `@PreAuthorize("hasRole('ROLE_ADMIN')")`를 추가하여 보안성을 강화했다.